### PR TITLE
MQTT paths don't generally start with a /

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ type outlet struct {
 }
 
 func (o outlet) CommandTopic() string {
-	return "/voltson/" + o.id
+	return "voltson/" + o.id
 }
 
 func (o outlet) AvailableTopic() string {


### PR DESCRIPTION
removing the leading slash to put this in line with general mqtt practice

eg:
![image](https://user-images.githubusercontent.com/567144/82150655-e36d6d00-9826-11ea-8912-121e320df1a7.png)
